### PR TITLE
Add some basic py3.5-compatibility

### DIFF
--- a/pyg/Pygemony.py
+++ b/pyg/Pygemony.py
@@ -1,10 +1,12 @@
+from __future__ import print_function
+
 from fnmatch import filter as fn_filter
 from os import walk, path
 import hashlib
 
-from utils import detect_mimetype
-from github import GithubAPIManager
-from languages import *
+from pyg.utils import detect_mimetype
+from pyg.github import GithubAPIManager
+from pyg.languages import *
 
 
 class Pygemony(object):
@@ -45,7 +47,7 @@ class Pygemony(object):
     @staticmethod
     def hash_todo(todo_content, file_name):
         m = hashlib.md5()
-        m.update('{}-{}'.format(todo_content, file_name))
+        m.update('{}-{}'.format(todo_content, file_name).encode('utf-8'))
         return str(m.hexdigest())
 
     def parse_for_todo(self, f, file_):
@@ -84,14 +86,14 @@ class Pygemony(object):
                 if file_type[0].startswith("application") or file_type[0] is None:
                     files_found.remove(file_)
             except (AttributeError, IndexError) as e:
-                print "Failed to open file {} with error of {}".format(file_, e)
+                print("Failed to open file {} with error of {}".format(file_, e))
 
         for file_ in files_found:
             try:
                 with open(file_, 'r') as f:
                     self.parse_for_todo(f, file_)
             except IOError as e:
-                print "Failed to open file {} with error of {}".format(file_, e)
+                print("Failed to open file {} with error of {}".format(file_, e))
 
         return files_found
 

--- a/pyg/github.py
+++ b/pyg/github.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import github3
 from os import path
 
@@ -30,7 +32,7 @@ class GithubAPIManager(object):
         try:
             return github3.login(self.user, self.token)
         except github3.models.GitHubError as e:
-            print "Failed to login due to {}".format(e)
+            print("Failed to login due to {}".format(e))
         return None
 
     def _save_submitted_todo(self, issue):
@@ -88,5 +90,5 @@ class GithubAPIManager(object):
     def _pprint(self, issue):
         msg = "Committing to repo: {}"
         msg += "\n\tFile Name: {}:{}\n\tTodo Message:{}"
-        print msg.format(self.repo, issue[0], issue[1], issue[2])
+        print(msg.format(self.repo, issue[0], issue[1], issue[2]))
     


### PR DESCRIPTION
This is just a basic patch to get the test to pass under Python 3.5 and isn't a full-fledged solution to supporting Python 2/3 in the future.

I'd recommend adding six as a dependency in a future patch.